### PR TITLE
build_trio.yml: use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/build_trio.yml
+++ b/.github/workflows/build_trio.yml
@@ -262,7 +262,7 @@ jobs:
       # Upload Build artifacts
       - name: Upload build log, IPA and Symbol artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: |


### PR DESCRIPTION
actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024